### PR TITLE
fix name/add repo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -721,9 +721,9 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "openssl"
-version = "0.10.62"
+version = "0.10.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cde4d2d9200ad5909f8dac647e29482e07c3a35de8a13fce7c9c7747ad9f671"
+checksum = "15c9d69dd87a29568d4d017cfe8ec518706046a05184e5aea92d0af890b803c8"
 dependencies = [
  "bitflags 2.4.2",
  "cfg-if",
@@ -762,9 +762,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.98"
+version = "0.9.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1665caf8ab2dc9aef43d1c0023bd904633a6a05cb30b0ad59bec2ae986e57a7"
+checksum = "22e1bf214306098e4832460f797824c05d25aacdf896f64a985fb0fd992454ae"
 dependencies = [
  "cc",
  "libc",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "opsml-cli"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "assert-json-diff",
@@ -892,9 +892,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.76"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
@@ -949,9 +949,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.2"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -961,9 +961,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+checksum = "3b7fa1134405e2ec9353fd416b17f8dacd46c473d7d3fd1cf202706a14eb792a"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1148,9 +1148,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b187f0231d56fe41bfb12034819dd2bf336422a5866de41bc3fec4b2e3883e8"
+checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "socket2"
@@ -1396,9 +1396,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
+checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
 dependencies = [
  "getrandom",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "opsml-cli"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "opsml-cli"
-version = "0.4.0"
+version = "0.4.1"
 description = "Rust-based CLI for interacting with OpsML"
 readme = "README.md"
 authors = [

--- a/src/api/model.rs
+++ b/src/api/model.rs
@@ -11,7 +11,7 @@ use std::path::PathBuf;
 use std::{fs, path::Path};
 use tokio;
 
-const MODEL_METADATA_FILE: &str = "metadata.json";
+const MODEL_METADATA_FILE: &str = "model-metadata.json";
 const NO_ONNX_URI: &str = "No onnx model uri found but onnx flag set to true";
 const NO_QUANTIZE_URI: &str = "No quantize model uri found but quantize flag set to true";
 
@@ -64,6 +64,7 @@ impl ModelDownloader<'_> {
 
         let model_metadata_request = types::ModelMetadataRequest {
             name: self.name,
+            repository: self.repository,
             version: self.version,
             uid: self.uid,
             ignore_release_candidates: self.ignore_release_candidates,

--- a/src/api/route_helper.rs
+++ b/src/api/route_helper.rs
@@ -206,6 +206,7 @@ mod tests {
             name: Some("name"),
             version: Some("version"),
             uid: Some("uid"),
+            repository: Some("repository"),
             ignore_release_candidates: &false,
         };
 

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -30,6 +30,7 @@ pub struct CardRequest<'a> {
 pub struct ModelMetadataRequest<'a> {
     pub name: Option<&'a str>,
     pub version: Option<&'a str>,
+    pub repository: Option<&'a str>,
     pub uid: Option<&'a str>,
     pub ignore_release_candidates: &'a bool,
 }


### PR DESCRIPTION
## Pull Request

### Short Summary
- Fixes metadata naming to use standardized name from `opsml` `metadata.json` -> `model-metadata.json`
- Adds `repository` to metadata request since it is now required for name uniqueness 
 
